### PR TITLE
Fix HGT link style selector

### DIFF
--- a/assets/styles/hgt.css
+++ b/assets/styles/hgt.css
@@ -51,7 +51,7 @@
 }
 
 .hgt-pagehead-nav a,
-.hgt-content .styleguide a,
+.hgt-content .styleguide:not(table) a,
 .hgt-footer a {
   color: #4183C4;
   text-decoration: none;


### PR DESCRIPTION
Currently the HGT styles are too specific to work with examples in [markup tables](https://github.com/holography/holograph/blob/master/docs/document-components.md#putting-examples-in-markup-tables). This change resolves that.