### PR TITLE
Feature/allow js config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ scss
 css
 /holograph
 .sass-cache
+typings
+jsconfig.json

--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Using the `--save` or `--save-dev` flag will add the dependency to your project'
 
 ## Configuration
 
-Settings for your Holograph instance are found in `holograph_config.yml` and use YAML syntax. To begin, copy the template configuration file into your project root with:
+Settings for your Holograph instance are found in either `holograph_config.yml` or `holograph_config.js` depending on your preference. To begin, copy your chosen language's template configuration file into your project root:
+
+JS:
+
+    cp node_mdules/holograph/holograph_config.js .
+
+YAML:
 
     cp node_modules/holograph/holograph_config.yml .
 

--- a/bin/holograph
+++ b/bin/holograph
@@ -1,33 +1,33 @@
 #!/usr/bin/env node
-var h = require('../');
-var fs = require('fs');
-var extend = require('extend');
-var yaml = require('js-yaml');
 
-var config = {
-    index_title: 'Home'
+const h = require('../');
+const configLoader = require('../libs/config/configLoader');
+const config = new configLoader();
+const logger = require('../libs/utils/logger');
+const exit = require('exit');
+
+/**
+ * Callback passed to Holograph.
+ *
+ * @param {Error} err Any errors that are thrown during Holograph build.
+ * @param {any} result Any result sent back from Holograph.
+ */
+function holographCallback (err, result) {
+
+    if (err) {
+        logger.logFailingError(err);
+        exit(1);
+    }
+
+    logger.logSuccessfulBuild();
+
 };
 
-function showError(message) {
-    if (message) {
-        console.log(message);
-        console.log('Build failed (╯°□°）╯︵ ┻━┻)'.red);
-        process.exit(1);
-    }
-}
-
-fs.readFile('holograph_config.yml', 'utf8',
-    function(err, data) {
-        if (err) {
-            if (err.code === 'ENOENT') {
-                showError('Could not find holograph_config.yml in the current directory.');
-            }
-        }
-
-        h.holograph(extend(config, yaml.safeLoad(data)), function(err, result) {
-            showError(err);
-            console.log('Build successful \\o\/'.green);
-        });
-    }
-);
-
+config.loadPromise()
+    .then(function (config) {
+        h.holograph(config, holographCallback)
+    })
+    .catch(function (err) {
+        logger.logFailingError(err);
+        exit(1);
+    });

--- a/docs/configure-holograph.md
+++ b/docs/configure-holograph.md
@@ -1,6 +1,6 @@
 # How to configure Holograph
 
-Settings for your Holograph instance are found in `holograph_config.yml` and use YAML syntax.
+Settings for your Holograph instance are found in either `holograph_config.js` or `holograph_config.yml`.
 
 Holograph will run from same directory where the config file resides: all paths should be relative to that location.
 

--- a/holograph_config.js
+++ b/holograph_config.js
@@ -1,0 +1,37 @@
+// Holograph will run from same directory where this config file resides
+// All paths should be relative to there
+module.exports = {
+  // The directory containing the source files to parse recursively
+  source: './scss',
+  // The directory that holograph will build to
+  destination: './holograph',
+  // The assets needed to build the docs (includes _header.html,
+  // _footer.html, etc)
+  // You may put doc related assets here too: images, css, etc.
+  documentation_assets: './node_modules/holograph/assets',
+  // Any other asset folders that need to be copied to the destination
+  // folder. Typically this will include the css that you are trying to
+  // document. May also include additional folders as needed.
+  dependencies: [
+    'css'
+  ],
+  css_include: [
+    'css/example.css'
+  ],
+  // Mark which category should be the index page
+  // Alternatively, you may have an index.md in the documentation assets
+  // folder instead of specifying this config.
+  index: 'basics',
+  // To additionally output navigation for top level sections, set the value to
+  // 'section'. To output navigation for sub-sections,
+  // set the value to `all`
+  // nav_level: all
+
+  // Holograph displays warnings when there are issues with your docs
+  // (e.g. if a component's parent is not found, if the _header.html and/or
+  //  _footer.html files aren't found)
+  // If you want Holograph to exit on these warnings, set the value to 'true'
+  // (Default value is 'false')
+  exit_on_warnings: false,
+  global_title: 'Holograph stylesheet'
+}

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -2,6 +2,7 @@
 
 const yaml = require('js-yaml');
 const fs = require('fs');
+const extend = require('extend');
 
 /**
  * Load configuration from files.
@@ -9,6 +10,7 @@ const fs = require('fs');
  * @class
  */
 function configLoader() {
+  this.defaultConfig = require('./defaultConfig');
 }
 
 /**
@@ -21,17 +23,26 @@ function configLoader() {
 configLoader.prototype.load = function () {
 
   if (this.hasJSConfig()) {
-    return this.loadJsConfig();
+    return this.mergeDefaultConfig(this.loadJsConfig());
   }
 
   if (this.hasYAMLConfig()) {
-    return this.loadYamlConfig();
+    return this.mergeDefaultConfig(this.loadYamlConfig());
   }
 
   // If we've not been able to find a config file, then bomb out.
   throw new Error('No holograph configuration file found.');
 
 };
+
+/**
+ * Merge loaded configuration with defaults.
+ *
+ * @returns {object} Loaded configuration merged with default required Holograph config.
+ */
+configLoader.prototype.mergeDefaultConfig = function (loadedConfig) {
+  return extend(this.defaultConfig, loadedConfig);
+}
 
 /**
  * Load a JavaScript based configuration file.

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -4,24 +4,23 @@ const yaml = require('js-yaml');
 const fs = require('fs');
 
 function configLoader() {
-  this.configType = this.getConfigExtension();
 }
+
 
 configLoader.prototype.load = function () {
 
-  if (this.configType === 'yml') {
-    return this._loadYamlConfig();
+  if (this._hasJSConfig()) {
+    return this._loadJsConfig();
   }
 
-  if (this.configType === 'js') {
-    return this._loadJsConfig();
+  if (this._hasYAMLConfig()) {
+    return this._loadYamlConfig();
   }
 
 };
 
 configLoader.prototype._loadJsConfig = function () {
-  const jsConfig = require('./holograph_config');
-  return jsConfig;
+  return require('./holograph_config');
 };
 
 configLoader.prototype._loadYamlConfig = function () {
@@ -52,17 +51,5 @@ configLoader.prototype._hasJSConfig = function () {
   return true;
 
 }
-
-configLoader.prototype.getConfigExtension = function () {
-
-  if (this._hasJSConfig()) {
-    return 'js';
-  }
-
-  if (this._hasYAMLConfig()) {
-    return 'yml';
-  }
-
-};
 
 module.exports = configLoader;

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const yaml = require('js-yaml');
+const fs = require('fs');
+
+function configLoader() {}
+
+configLoader.prototype.load = function () {
+  return yaml.safeLoad(fs.readFileSync('holograph_config.yml', 'utf8'));
+};
+
+configLoader.prototype._hasYAMLConfig = function () {
+
+  try {
+    fs.statSync('holograph_config.yml');
+  } catch (err) {
+    return false;
+  }
+
+  return true;
+
+};
+
+configLoader.prototype._hasJSConfig = function () {
+
+  try {
+    fs.statSync('holograph_config.js');
+  } catch (err) {
+    return false;
+  }
+
+  return true;
+
+}
+
+configLoader.prototype.getConfigExtension = function () {
+
+  if (this._hasJSConfig()) {
+    return 'js';
+  }
+
+  if (this._hasYAMLConfig()) {
+    return 'yml';
+  }
+
+};
+
+module.exports = configLoader;

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -3,6 +3,7 @@
 const yaml = require('js-yaml');
 const fs = require('fs');
 const extend = require('extend');
+const Promise = require('bluebird');
 
 /**
  * Load configuration from files.
@@ -32,6 +33,30 @@ configLoader.prototype.load = function () {
 
   // If we've not been able to find a config file, then bomb out.
   throw new Error('No holograph configuration file found.');
+
+};
+
+/**
+ * Load configuration from either a JS or YAML file into a promise.
+ *
+ * @returns {Promise} A promise that resolves with either the loaded configuration, or rejects with any errors raised.
+ */
+configLoader.prototype.loadPromise = function () {
+
+  let config;
+
+  return new Promise(function(resolve, reject) {
+
+    try {
+      config = this.load();
+    }
+    catch(err) {
+      reject(err.toString());
+    }
+
+    resolve(config);
+
+  }.bind(this));
 
 };
 

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 function configLoader() {
 }
 
-
 configLoader.prototype.load = function () {
 
   if (this._hasJSConfig()) {
@@ -16,6 +15,8 @@ configLoader.prototype.load = function () {
   if (this._hasYAMLConfig()) {
     return this._loadYamlConfig();
   }
+
+  throw new Error('No holograph configuration file found.');
 
 };
 

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -3,10 +3,30 @@
 const yaml = require('js-yaml');
 const fs = require('fs');
 
-function configLoader() {}
+function configLoader() {
+  this.configType = this.getConfigExtension();
+}
 
 configLoader.prototype.load = function () {
-  return yaml.safeLoad(fs.readFileSync('holograph_config.yml', 'utf8'));
+
+  if (this.configType === 'yml') {
+    return this._loadYamlConfig();
+  }
+
+  if (this.configType === 'js') {
+    return this._loadJsConfig();
+  }
+
+};
+
+configLoader.prototype._loadJsConfig = function () {
+  const jsConfig = require('./holograph_config');
+  return jsConfig;
+};
+
+configLoader.prototype._loadYamlConfig = function () {
+  const yamlConfig = fs.readFileSync('holograph_config.yml');
+  return yaml.safeLoad(yamlConfig);
 };
 
 configLoader.prototype._hasYAMLConfig = function () {

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -3,33 +3,63 @@
 const yaml = require('js-yaml');
 const fs = require('fs');
 
+/**
+ * Load configuration from files.
+ *
+ * @class
+ */
 function configLoader() {
 }
 
+/**
+ * Load configuration from either a JS or YAML file.
+ *
+ * @throws {Error} Thrown if no YAML or JavaScript config file is found.
+ *
+ * @returns {object} Holograph configuration.
+ */
 configLoader.prototype.load = function () {
 
-  if (this._hasJSConfig()) {
-    return this._loadJsConfig();
+  if (this.hasJSConfig()) {
+    return this.loadJsConfig();
   }
 
-  if (this._hasYAMLConfig()) {
-    return this._loadYamlConfig();
+  if (this.hasYAMLConfig()) {
+    return this.loadYamlConfig();
   }
 
+  // If we've not been able to find a config file, then bomb out.
   throw new Error('No holograph configuration file found.');
 
 };
 
-configLoader.prototype._loadJsConfig = function () {
+/**
+ * Load a JavaScript based configuration file.
+ *
+ * @returns {object} Holograph configuration loaded from a JavaScript file.
+ */
+configLoader.prototype.loadJsConfig = function () {
   return require('./holograph_config');
 };
 
-configLoader.prototype._loadYamlConfig = function () {
+/**
+ * Load a YAML based configuration file.
+ *
+ * @returns {object} Holograph configuration loaded from a YAML file.
+ */
+configLoader.prototype.loadYamlConfig = function () {
+  // We don't really need to wrap this in a try/catch as chekcing for the existence of this file hapens directly prior
+  // to loading it in. Maybe.
   const yamlConfig = fs.readFileSync('holograph_config.yml');
   return yaml.safeLoad(yamlConfig);
 };
 
-configLoader.prototype._hasYAMLConfig = function () {
+/**
+ * Check to see if a YAML config file exists.
+ *
+ * @returns {bool} True if a YAML config file exists, false if not.
+ */
+configLoader.prototype.hasYAMLConfig = function () {
 
   try {
     fs.statSync('holograph_config.yml');
@@ -41,7 +71,12 @@ configLoader.prototype._hasYAMLConfig = function () {
 
 };
 
-configLoader.prototype._hasJSConfig = function () {
+/**
+ * Check to see if a JavaScript config file exists.
+ *
+ * @returns {bool} True if a JavaScript config file exists, false if not.
+ */
+configLoader.prototype.hasJSConfig = function () {
 
   try {
     fs.statSync('holograph_config.js');

--- a/libs/config/configLoader.js
+++ b/libs/config/configLoader.js
@@ -51,7 +51,7 @@ configLoader.prototype.loadPromise = function () {
       config = this.load();
     }
     catch(err) {
-      reject(err.toString());
+      reject(err);
     }
 
     resolve(config);

--- a/libs/config/defaultConfig.js
+++ b/libs/config/defaultConfig.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  index_title: 'Home'
+};

--- a/libs/utils/logger.js
+++ b/libs/utils/logger.js
@@ -5,4 +5,26 @@ const logger = require("eazy-logger").Logger({
   useLevelPrefixes: true
 });
 
+/**
+ * Log an error that fails a build.
+ *
+ * @param {Error} err
+ */
+logger.logFailingError = function (error) {
+
+  if (typeof error !== 'undefined') {
+    this.error(error.toString());
+  }
+
+  this.error('Build failed (╯°□°）╯︵ ┻━┻)');
+
+};
+
+/**
+ * Log a build sucessful message.
+ */
+logger.logSuccessfulBuild = function () {
+  this.info('Build successful \\o\/');
+};
+
 module.exports = logger;

--- a/libs/utils/logger.js
+++ b/libs/utils/logger.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const logger = require("eazy-logger").Logger({
+  prefix: '{blue:[}{magenta:Holograph}{blue:] }',
+  useLevelPrefixes: true
+});
+
+module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "mocha": "^3.1.2",
     "mock-fs": "^3.9.0",
     "proxyquire": "^1.7.10",
-    "sinon": "^1.17.6",
-    "sinon-chai": "^2.8.0",
     "typings": "^2.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "typings": "^2.0.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/*"
+    "test": "./node_modules/.bin/mocha --recursive"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "bluebird": "^3.4.6",
     "colors": "^1.1.2",
     "dive": "^0.5.0",
+    "eazy-logger": "^3.0.2",
     "exit": "^0.1.2",
     "extend": "^3.0.0",
     "highlight.js": "^9.7.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.1.2",
-    "mock-fs": "^3.9.0"
+    "mock-fs": "^3.9.0",
+    "typings": "^2.0.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "./node_modules/.bin/mocha test/*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
+    "bluebird": "^3.4.6",
     "colors": "^1.1.2",
     "dive": "^0.5.0",
+    "exit": "^0.1.2",
     "extend": "^3.0.0",
     "highlight.js": "^9.7.0",
     "js-yaml": "^3.6.1",
@@ -22,6 +24,8 @@
     "mocha": "^3.1.2",
     "mock-fs": "^3.9.0",
     "proxyquire": "^1.7.10",
+    "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0",
     "typings": "^2.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "chai": "^3.5.0",
     "mocha": "^3.1.2",
     "mock-fs": "^3.9.0",
+    "proxyquire": "^1.7.10",
     "typings": "^2.0.0"
   },
   "scripts": {

--- a/test/config/configLoaderSpec.js
+++ b/test/config/configLoaderSpec.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// Module imports.
+const configLoader = require('../../libs/config/configLoader');
+const expect = require('chai').expect;
+const mock = require('mock-fs');
+const fs = require('fs');
+
+// Fixture imports.
+const YAMLConfigFixture = fs.readFileSync('test/fixtures/holograph_config.yml');
+const JSConfigFixture = require('../fixtures/holograph_config');
+
+describe('configLoader', function () {
+
+  describe('location', function () {
+
+    let loader;
+
+    afterEach(function () {
+      mock.restore();
+      loader = {};
+    });
+
+    it('can locate YAML config files', function () {
+
+      mock({
+        'holograph_config.yml': YAMLConfigFixture
+      });
+
+      loader = new configLoader();
+
+      expect(loader.getConfigExtension()).to.equal('yml');
+
+    })
+
+    it('can locate JS config files', function () {
+
+      mock({
+        'holograph_config.js': JSConfigFixture
+      });
+
+      loader = new configLoader();
+
+      expect(loader.getConfigExtension()).to.equal('js');
+
+    });
+
+    it('prefers JS files over YAML files', function () {
+
+      mock({
+        'holograph_config.yml': YAMLConfigFixture,
+        'holograph_config.js': JSConfigFixture
+      });
+
+      loader = new configLoader();
+
+      expect(loader.getConfigExtension()).to.equal('js');
+    });
+
+  });
+
+  // describe('loading', function () {
+
+  //   let loader;
+
+  //   afterEach(function () {
+  //     mock.restore();
+  //     loader = {};
+  //   });
+
+    // it('can load YAML config', function () {
+
+    //   mock({
+    //     'holograph_config.yml': YAMLConfigFixture
+    //   });
+
+    //   loader = new configLoader();
+    //   config = loader.load();
+
+    //   expect(config.global_title).to.equal('Holograph stylesheet - YAML');
+
+    // });
+
+    // it('can load JS config', function () {
+
+    //   mock({
+    //     'holograph_config.js': JSConfigFixture
+    //   });
+
+    //   expect(config.global_title).to.equal('Holograph stylesheet - JavaScript');
+
+    // });
+
+  // });
+
+
+});

--- a/test/config/configLoaderSpec.js
+++ b/test/config/configLoaderSpec.js
@@ -1,18 +1,23 @@
 'use strict';
 
 // Module imports.
-const configLoader = require('../../libs/config/configLoader');
 const expect = require('chai').expect;
 const mock = require('mock-fs');
 const fs = require('fs');
+const proxyquire = require('proxyquire').noCallThru();
 
 // Fixture imports.
 const YAMLConfigFixture = fs.readFileSync('test/fixtures/holograph_config.yml');
 const JSConfigFixture = require('../fixtures/holograph_config');
 
+// SUT.
+const configLoader = proxyquire('../../libs/config/configLoader', {
+  './holograph_config': require('../fixtures/holograph_config.js')
+});
+
 describe('configLoader', function () {
 
-  describe('location', function () {
+  describe('locator', function () {
 
     let loader;
 
@@ -55,43 +60,51 @@ describe('configLoader', function () {
       loader = new configLoader();
 
       expect(loader.getConfigExtension()).to.equal('js');
+
     });
 
   });
 
-  // describe('loading', function () {
+  describe('loading', function () {
 
-  //   let loader;
+    let loader;
+    let config;
 
-  //   afterEach(function () {
-  //     mock.restore();
-  //     loader = {};
-  //   });
+    afterEach(function () {
+      mock.restore();
+      loader = {};
+      config = {};
+    });
 
-    // it('can load YAML config', function () {
+    it('can load YAML config', function () {
 
-    //   mock({
-    //     'holograph_config.yml': YAMLConfigFixture
-    //   });
+      mock({
+        'holograph_config.yml': YAMLConfigFixture
+      });
 
-    //   loader = new configLoader();
-    //   config = loader.load();
+      loader = new configLoader();
+      config = loader.load();
 
-    //   expect(config.global_title).to.equal('Holograph stylesheet - YAML');
+      expect(config.global_title).to.equal('Holograph stylesheet - YAML');
 
-    // });
+    });
 
-    // it('can load JS config', function () {
+    it('can load JS config', function () {
 
-    //   mock({
-    //     'holograph_config.js': JSConfigFixture
-    //   });
+      mock({
+        'holograph_config.js': fs.readFileSync('test/fixtures/holograph_config.js').toString()
+      });
 
-    //   expect(config.global_title).to.equal('Holograph stylesheet - JavaScript');
+      // const stubbedJSConfig = proxyquire('./holograph_config', {foo: 'bar'}).noCallThru();
 
-    // });
+      loader = new configLoader();
+      config = loader.load();
 
-  // });
+      expect(config.global_title).to.equal('Holograph stylesheet - JavaScript');
+
+    });
+
+  });
 
 
 });

--- a/test/config/configLoaderSpec.js
+++ b/test/config/configLoaderSpec.js
@@ -104,4 +104,64 @@ describe('configLoader', function () {
 
   });
 
+  describe('promise loading', function () {
+
+    let loader;
+    let config;
+
+    afterEach(function () {
+      mock.restore();
+      loader = {};
+      config = {};
+    });
+
+    it('can load YAML config with a promise', function (done) {
+
+      mock({
+        'holograph_config.yml': YAMLConfigFixture,
+      });
+
+      loader = new configLoader();
+      loader.loadPromise()
+        .then(function (config) {
+          expect(config.global_title).to.equal('Holograph stylesheet - YAML');
+          done();
+        })
+        .catch(done);
+
+    });
+
+    it('can load JS config with a promise', function (done) {
+
+      mock({
+        'holograph_config.js': JSConfigFixture,
+      });
+
+      loader = new configLoader();
+      loader.loadPromise()
+        .then(function (config) {
+          expect(config.global_title).to.equal('Holograph stylesheet - JavaScript');
+          done();
+        })
+        .catch(done);
+
+    });
+
+    it('rejects the promise if there\'s an error', function (done) {
+
+      mock({
+        'dummy.txt': 'I am a dummy file.'
+      });
+
+      loader = new configLoader();
+
+      loader.loadPromise()
+        .catch(function (err) {
+          done();
+        });
+
+    });
+
+  });
+
 });

--- a/test/config/configLoaderSpec.js
+++ b/test/config/configLoaderSpec.js
@@ -17,54 +17,6 @@ const configLoader = proxyquire('../../libs/config/configLoader', {
 
 describe('configLoader', function () {
 
-  describe('locator', function () {
-
-    let loader;
-
-    afterEach(function () {
-      mock.restore();
-      loader = {};
-    });
-
-    it('can locate YAML config files', function () {
-
-      mock({
-        'holograph_config.yml': YAMLConfigFixture
-      });
-
-      loader = new configLoader();
-
-      expect(loader.getConfigExtension()).to.equal('yml');
-
-    })
-
-    it('can locate JS config files', function () {
-
-      mock({
-        'holograph_config.js': JSConfigFixture
-      });
-
-      loader = new configLoader();
-
-      expect(loader.getConfigExtension()).to.equal('js');
-
-    });
-
-    it('prefers JS files over YAML files', function () {
-
-      mock({
-        'holograph_config.yml': YAMLConfigFixture,
-        'holograph_config.js': JSConfigFixture
-      });
-
-      loader = new configLoader();
-
-      expect(loader.getConfigExtension()).to.equal('js');
-
-    });
-
-  });
-
   describe('loading', function () {
 
     let loader;
@@ -96,6 +48,20 @@ describe('configLoader', function () {
       });
 
       // const stubbedJSConfig = proxyquire('./holograph_config', {foo: 'bar'}).noCallThru();
+
+      loader = new configLoader();
+      config = loader.load();
+
+      expect(config.global_title).to.equal('Holograph stylesheet - JavaScript');
+
+    });
+
+    it('prefers JS config over YAML config', function () {
+
+      mock({
+        'holograph_config.yml': YAMLConfigFixture,
+        'holograph_config.js': JSConfigFixture
+      });
 
       loader = new configLoader();
       config = loader.load();

--- a/test/config/configLoaderSpec.js
+++ b/test/config/configLoaderSpec.js
@@ -12,7 +12,10 @@ const JSConfigFixture = require('../fixtures/holograph_config');
 
 // SUT.
 const configLoader = proxyquire('../../libs/config/configLoader', {
-  './holograph_config': require('../fixtures/holograph_config.js')
+  './holograph_config': require('../fixtures/holograph_config.js'),
+  './defaultConfig': {
+    'test_config': 'I am a serious expectation.'
+  }
 });
 
 describe('configLoader', function () {
@@ -83,6 +86,19 @@ describe('configLoader', function () {
       }
 
       expect(loaderFunc).to.throw(Error, 'No holograph configuration file found.');
+
+    });
+
+    it('merges loaded config with defaults', function () {
+
+      mock({
+        'holograph_config.js': JSConfigFixture
+      });
+
+      loader = new configLoader();
+      config = loader.load();
+
+      expect(config.test_config).to.equal('I am a serious expectation.');
 
     });
 

--- a/test/config/configLoaderSpec.js
+++ b/test/config/configLoaderSpec.js
@@ -47,8 +47,6 @@ describe('configLoader', function () {
         'holograph_config.js': fs.readFileSync('test/fixtures/holograph_config.js').toString()
       });
 
-      // const stubbedJSConfig = proxyquire('./holograph_config', {foo: 'bar'}).noCallThru();
-
       loader = new configLoader();
       config = loader.load();
 
@@ -70,7 +68,24 @@ describe('configLoader', function () {
 
     });
 
-  });
+    it('throws an error if no config was found', function () {
 
+      mock({
+        'dummy.txt': 'I am a dummy file.'
+      });
+
+      loader = new configLoader();
+
+      // This has to be in a callable for some reason, as Chai fails miserably then you just pass loader.load to
+      // expect()
+      const loaderFunc = function () {
+        loader.load();
+      }
+
+      expect(loaderFunc).to.throw(Error, 'No holograph configuration file found.');
+
+    });
+
+  });
 
 });

--- a/test/fixtures/holograph_config.js
+++ b/test/fixtures/holograph_config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  source: './scss',
+  destination: './holograph',
+  documentation_assets: './node_modules/holograph/assets',
+  dependencies: [
+    'css'
+  ],
+  css_include: [
+    'css/example.css'
+  ],
+  index: 'basics',
+  exit_on_warnings: false,
+  global_title: 'Holograph stylesheet - JavaScript'
+}

--- a/test/fixtures/holograph_config.yml
+++ b/test/fixtures/holograph_config.yml
@@ -1,0 +1,41 @@
+# Holograph will run from same directory where this config file resides
+# All paths should be relative to there
+
+# The directory containing the source files to parse recursively
+source: ./scss
+
+# The directory that holograph will build to
+destination: ./holograph
+
+# The assets needed to build the docs (includes _header.html,
+# _footer.html, etc)
+# You may put doc related assets here too: images, css, etc.
+documentation_assets: ./node_modules/holograph/assets
+
+# Any other asset folders that need to be copied to the destination
+# folder. Typically this will include the css that you are trying to
+# document. May also include additional folders as needed.
+dependencies:
+  - css
+
+css_include:
+  - css/example.css
+
+# Mark which category should be the index page
+# Alternatively, you may have an index.md in the documentation assets
+# folder instead of specifying this config.
+index: basics
+
+# To additionally output navigation for top level sections, set the value to
+# 'section'. To output navigation for sub-sections,
+# set the value to `all`
+# nav_level: all
+
+# Holograph displays warnings when there are issues with your docs
+# (e.g. if a component's parent is not found, if the _header.html and/or
+#  _footer.html files aren't found)
+# If you want Holograph to exit on these warnings, set the value to 'true'
+# (Default value is 'false')
+exit_on_warnings: false
+
+global_title: Holograph stylesheet - YAML

--- a/test/utils/loggerSpec.js
+++ b/test/utils/loggerSpec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Module imports.
+const chai = require('chai');
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
+const eazy = require('eazy-logger');
+// SUT.
+const logger = require('../../libs/utils/logger');
+
+// Chai setup.
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe('logger', function () {
+
+  it('extends eazy-logger', function () {
+
+    expect(logger).to.be.an.instanceof(eazy.Logger);
+
+  });
+
+  it('adds a custom prefix to log messages', function () {
+
+    const prefix = '{blue:[}{magenta:Holograph}{blue:] }';
+    expect(logger.config.prefix).to.equal(prefix);
+
+  });
+
+});

--- a/test/utils/loggerSpec.js
+++ b/test/utils/loggerSpec.js
@@ -1,17 +1,11 @@
 'use strict';
 
 // Module imports.
-const chai = require('chai');
-const sinon = require("sinon");
-const sinonChai = require("sinon-chai");
+const expect = require('chai').expect;
 const eazy = require('eazy-logger');
 
 // SUT.
 const logger = require('../../libs/utils/logger');
-
-// Chai setup.
-const expect = chai.expect;
-chai.use(sinonChai);
 
 describe('logger', function () {
 

--- a/test/utils/loggerSpec.js
+++ b/test/utils/loggerSpec.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 const sinon = require("sinon");
 const sinonChai = require("sinon-chai");
 const eazy = require('eazy-logger');
+
 // SUT.
 const logger = require('../../libs/utils/logger');
 

--- a/typings.json
+++ b/typings.json
@@ -2,7 +2,9 @@
   "name": "holograph",
   "dependencies": {},
   "globalDependencies": {
+    "bluebird": "registry:dt/bluebird#3.0.0+20161007114152",
     "colors": "registry:dt/colors#0.6.0-1+20160914114039",
+    "exit": "registry:dt/exit#0.1.2+20160316155526",
     "extend": "registry:dt/extend#2.0.0+20160316155526",
     "js-yaml": "registry:dt/js-yaml#3.5.2+20160316171810",
     "mustache": "registry:dt/mustache#0.8.2+20160316155526",
@@ -14,6 +16,8 @@
     "chai": "registry:dt/chai#3.4.0+20160601211834",
     "mocha": "registry:dt/mocha#2.2.5+20161028141524",
     "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654",
-    "proxyquire": "registry:dt/proxyquire#1.3.0+20160316155526"
+    "proxyquire": "registry:dt/proxyquire#1.3.0+20160316155526",
+    "sinon": "registry:dt/sinon#1.16.0+20160924120326",
+    "sinon-chai": "registry:dt/sinon-chai#2.7.0+20160317120654"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,18 @@
+{
+  "name": "holograph",
+  "dependencies": {},
+  "globalDependencies": {
+    "colors": "registry:dt/colors#0.6.0-1+20160914114039",
+    "extend": "registry:dt/extend#2.0.0+20160316155526",
+    "js-yaml": "registry:dt/js-yaml#3.5.2+20160316171810",
+    "mustache": "registry:dt/mustache#0.8.2+20160316155526",
+    "ncp": "registry:dt/ncp#0.5.1+20160906145159",
+    "node": "registry:dt/node#6.0.0+20161110151007",
+    "rimraf": "registry:dt/rimraf#0.0.0+20160317120654"
+  },
+  "globalDevDependencies": {
+    "chai": "registry:dt/chai#3.4.0+20160601211834",
+    "mocha": "registry:dt/mocha#2.2.5+20161028141524",
+    "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654"
+  }
+}

--- a/typings.json
+++ b/typings.json
@@ -13,6 +13,7 @@
   "globalDevDependencies": {
     "chai": "registry:dt/chai#3.4.0+20160601211834",
     "mocha": "registry:dt/mocha#2.2.5+20161028141524",
-    "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654"
+    "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654",
+    "proxyquire": "registry:dt/proxyquire#1.3.0+20160316155526"
   }
 }

--- a/typings.json
+++ b/typings.json
@@ -16,8 +16,6 @@
     "chai": "registry:dt/chai#3.4.0+20160601211834",
     "mocha": "registry:dt/mocha#2.2.5+20161028141524",
     "mock-fs": "registry:dt/mock-fs#3.6.0+20160317120654",
-    "proxyquire": "registry:dt/proxyquire#1.3.0+20160316155526",
-    "sinon": "registry:dt/sinon#1.16.0+20160924120326",
-    "sinon-chai": "registry:dt/sinon-chai#2.7.0+20160317120654"
+    "proxyquire": "registry:dt/proxyquire#1.3.0+20160316155526"
   }
 }


### PR DESCRIPTION
This PR covers #41, and adds a small refactor on the binary to cover the changes.

It allows for YAML to also be parsed, so it's not a breaking change. It also removes the requirement for a Gulp plugin if using the JS config file, which should probably (?) be the recommended approach?